### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Relay/keywords.txt
+++ b/Relay/keywords.txt
@@ -1,4 +1,4 @@
-Relay KEYWORD1
-open KEYWORD2
-close KEYWORD2
-openOn KEYWORD2
+Relay	KEYWORD1
+open	KEYWORD2
+close	KEYWORD2
+openOn	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords